### PR TITLE
Fix crash when saving album artwork to vorbis audio file

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/activities/tageditor/WriteTagsAsyncTask.java
+++ b/app/src/main/java/code/name/monkey/retromusic/activities/tageditor/WriteTagsAsyncTask.java
@@ -18,7 +18,6 @@ import org.jaudiotagger.tag.FieldKey;
 import org.jaudiotagger.tag.Tag;
 import org.jaudiotagger.tag.TagException;
 import org.jaudiotagger.tag.images.Artwork;
-import org.jaudiotagger.tag.images.ArtworkFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import code.name.monkey.retromusic.R;
 import code.name.monkey.retromusic.misc.DialogAsyncTask;
+import code.name.monkey.retromusic.misc.MyAndroidArtwork;
 import code.name.monkey.retromusic.misc.UpdateToastMediaScannerCompletionListener;
 import code.name.monkey.retromusic.util.MusicUtil;
 
@@ -53,9 +53,9 @@ public class WriteTagsAsyncTask extends
             if (info.artworkInfo != null && info.artworkInfo.getArtwork() != null) {
                 try {
                     albumArtFile = MusicUtil.createAlbumArtFile().getCanonicalFile();
-                    info.artworkInfo.getArtwork()
-                            .compress(Bitmap.CompressFormat.PNG, 0, new FileOutputStream(albumArtFile));
-                    artwork = ArtworkFactory.createArtworkFromFile(albumArtFile);
+                    Bitmap artworkBitmap = info.artworkInfo.getArtwork();
+                    artworkBitmap.compress(Bitmap.CompressFormat.PNG, 0, new FileOutputStream(albumArtFile));
+                    artwork = MyAndroidArtwork.create(albumArtFile, artworkBitmap);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/code/name/monkey/retromusic/misc/MyAndroidArtwork.java
+++ b/app/src/main/java/code/name/monkey/retromusic/misc/MyAndroidArtwork.java
@@ -1,0 +1,60 @@
+package code.name.monkey.retromusic.misc;
+
+import android.graphics.Bitmap;
+
+import org.jaudiotagger.tag.images.AndroidArtwork;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * This is a fork from jaudiotagger's AndroidArtwork, which doesn't implement
+ * some Artwork methods and throws UnsupportedOperationException.
+ *
+ */
+public class MyAndroidArtwork extends AndroidArtwork
+{
+    private Bitmap          bitmap;
+
+    public MyAndroidArtwork()
+    {
+
+    }
+
+    /**
+     * Should be called when you wish to prime the artwork for saving
+     *
+     * This implementation tries to copy jaudiotagger's StandardArwork using
+     * android's Bitmap class instead of java.awt's Image class.
+     * https://bitbucket.org/ijabz/jaudiotagger/src/ddd521dba64331be36f3ee8c3e3f408cdd7eee15/src/org/jaudiotagger/tag/images/StandardArtwork.java?at=master&fileviewer=file-view-default#StandardArtwork.java-78
+     *
+     * @return true if this instance has a valid bitmap and was able to retrieve
+     * the bitmap's dimensions.
+     */
+    public boolean setImageFromData()
+    {
+        if (bitmap != null) {
+            setWidth(bitmap.getWidth());
+            setHeight(bitmap.getHeight());
+            return true;
+        }
+        return false;
+    }
+
+    public Bitmap getBitmap() {
+        return bitmap;
+    }
+
+    public void setBitmap(Bitmap bitmap) {
+        this.bitmap = bitmap;
+    }
+
+    public static MyAndroidArtwork create(File file, Bitmap bitmap)  throws IOException
+    {
+        MyAndroidArtwork artwork = new MyAndroidArtwork();
+        artwork.setFromFile(file);
+        artwork.setBitmap(bitmap);
+        return artwork;
+    }
+
+}


### PR DESCRIPTION
My music library is almost entirely vorbis files and I had an issue when saving album artwork from local storage. The app would crash every single time and the stack trace was inside the android framework's `MediaScannerConnection` class.

I sent a bug report with the stack trace yesterday, but since I had some free time today I tried to debug it. The first problem that I found was that `WriteTagsAsyncTask`'s `doInBackground()` method was returning null. `MediaScannerConnection.scanFile()` fails if it receives null as the paths array. 

The reason why `execute` was returning null was more interesting. When `Tag.setField()` receives an `Artwork` instance, it calls `Artwork.setImageFromData()`. The problem was that the implementation that was being used, `AndroidArtwork`, does not implement it. It just throws `UnsupportedOperationException`. 

I created `MyAndroidArtwork` class extending `AndroidArtwork` so that it implements the method correctly, mimicking [jaudiotagger's `StandardArtwork`](https://bitbucket.org/ijabz/jaudiotagger/src/ddd521dba64331be36f3ee8c3e3f408cdd7eee15/src/org/jaudiotagger/tag/images/StandardArtwork.java?at=master&fileviewer=file-view-default#StandardArtwork.java-78). I think it would be better to patch the android fork of jaudiotagger, but that may take a while.

Also please note that there could still occur more errors when writing tags since it's an I/O operation. If `WriteTagsAsyncTask`'s `doInBackground` method returns null, `MediaScannerConnection` should not be invoked and an error should be displayed. I could implement it, but I don't know if you have a generic way to display errors.