### PR TITLE
Update SlidingUpPanel and remove unnecessary repositories-block

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     implementation 'me.zhanghai.android.materialprogressbar:library:1.4.2'
     implementation 'com.r0adkll:slidableactivity:2.0.6'
     /*Backend all*/
-    implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:3.3.0-kmod3'
+    implementation 'com.github.kabouzeid:AndroidSlidingUpPanel:3.3.3-kmod'
     implementation 'com.github.AdrienPoupa:jaudiotagger:2.2.3'
     implementation 'org.nanohttpd:nanohttpd:2.3.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
@@ -165,6 +165,4 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation project(':appthemehelper')
 }
-repositories {
-    mavenCentral()
-}
+


### PR DESCRIPTION
As you can see [here](https://jitpack.io/#kabouzeid/AndroidSlidingUpPanel), the version 3.3.0-kmod3 isn't even available on jitpack.

Therefore, I propose updating to a version that IS available on jitpack. Also I removed the unneccessary repositories-block since it gets overriden by the project-wide gradle-file anyways.