### PR TITLE
Fix a problem about DeezerApiService

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/deezer/DeezerApiService.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/deezer/DeezerApiService.kt
@@ -52,8 +52,7 @@ interface DeezerApiService {
                         .addHeader("Cache-Control",
                                 String.format(
                                         Locale.getDefault(),
-                                        "max-age=%d, max-stale=%d",
-                                        31536000, 31536000
+                                        "max-age=31536000, max-stale=31536000"
                                 )
                         ).build()
                 chain.proceed(modifiedRequest)


### PR DESCRIPTION
These changes fix a crash. This crash is for non international language integers like Persian.