### PR TITLE
Rename the app to simply "Retro".

### DIFF
--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -11,7 +11,7 @@
         <item>code_name_monkey_donate_8</item>
     </string-array>
 
-    <string name="app_name" translatable="false">Retro Music</string>
+    <string name="app_name" translatable="false">Retro</string>
     <string name="git_hub" translatable="false">GitHub</string>
 
 


### PR DESCRIPTION
 * On some devices "Retro Music" can trail off the label.