### PR TITLE
Fixed search bug

### DIFF
--- a/app/src/main/java/code/name/monkey/retromusic/repository/SearchRepository.kt
+++ b/app/src/main/java/code/name/monkey/retromusic/repository/SearchRepository.kt
@@ -45,10 +45,8 @@ class RealSearchRepository(
                 results.add(context.resources.getString(R.string.albums))
                 results.addAll(albums)
             }
-            val genres: List<Genre> = genreRepository.genres().filter { genre ->
-                genre.name.toLowerCase(Locale.getDefault())
-                    .contains(searchString.toLowerCase(Locale.getDefault()))
-            }
+
+            val genres = genreRepository.genres(searchString)
             if (genres.isNotEmpty()) {
                 results.add(context.resources.getString(R.string.genres))
                 results.addAll(genres)


### PR DESCRIPTION
### Reason

Old search code in GenreRepository.kt was very slow on large libraries.

### Code Changes:
- Used selection parameters for contentResolver.query instead of fetching all genres and filtering afterwards.
- Changed code in SearchRepository.kt to call new function.